### PR TITLE
Fix: nav-header's unwanted BLACK solid top border

### DIFF
--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -2,7 +2,7 @@
  * Site header
  */
 .site-header {
-    border-top: 5px solid $grey-color-dark;
+    border-top: 1px solid $grey-color-light;
     border-bottom: 1px solid $grey-color-light;
     min-height: 56px;
 


### PR DESCRIPTION
This edit fixes the nav-header's unwanted solid top border (BLACK) at the top of the page.